### PR TITLE
Typos

### DIFF
--- a/developing/basics.md
+++ b/developing/basics.md
@@ -68,7 +68,7 @@ In this section, we'll cover where to find the files that are important for deve
 Your account's files all live under the home folder. This directory contains standard organizational folders like `Documents` or `Downloads`, as well as folders that are unique to Stretch's SDK, such as:
 
  - `stretch_user`: The [Stretch User folder](#the-stretch-user-folder) is required to be present in the home directory for Stretch's SDK to work correctly. It contains calibration data unique to your robot and assets (e.g. neural net checkpoints, maps for navigation, etc.) used by various programs. If you're missing this directory, reach out to support.
- - `ament_ws`: The Ament Workspace folder contains Stretch's ROS2 SDK. This directory will be covered in more detail in the [Using ROS 2 with Stretch](#TODO) tutorial. If this folder is missing, you may be using an older [robot distribution](../../../software/distributions/) and should consider upgrading.
+ - `ament_ws`: The Ament Workspace folder contains Stretch's ROS 2 SDK. This directory will be covered in more detail in the [Using ROS 2 with Stretch](#TODO) tutorial. If this folder is missing, you may be using an older [robot distribution](../../../software/distributions/) and should consider upgrading.
  - `catkin_ws`: The Catkin Workspace folder contains Stretch's ROS1 SDK. If this folder exists, you may be using an older [robot distribution](../../../software/distributions/) and should consider upgrading.
 
 ![files](./images/files.png)
@@ -79,8 +79,8 @@ The Stretch User folder contains calibration data unique to your robot and asset
 
  - `stretch-yyy-xxxx`: This is the [robot calibration directory](#the-robot-calibration-folder). Its naming scheme is "stretch-" following by "re1" for a Stretch RE1, "re2" for a Stretch 2, or "se3" for a Stretch 3, finally followed by your robot's four digit serial number.
  - `stretch_deep_perception_models`: This directory contains open deep learning models from third parties, including object detection, head detection, facial landmarks detection, and human pose detection.
- - `maps`: This directory contains [occupancy maps](https://www.cs.cmu.edu/~16831-f14/notes/F14/16831_lecture06_agiri_dmcconac_kumarsha_nbhakta.pdf) that are to be used with the Stretch Nav2 ROS2 package.
- - `debug`: This directory contains debug output from the Stretch FUNMAP ROS2 package.
+ - `maps`: This directory contains [occupancy maps](https://www.cs.cmu.edu/~16831-f14/notes/F14/16831_lecture06_agiri_dmcconac_kumarsha_nbhakta.pdf) that are to be used with the Stretch Nav2 ROS 2 package.
+ - `debug`: This directory contains debug output from the Stretch FUNMAP ROS 2 package.
  - `log`: This directory contains logfiles from various Stretch programs.
 
 ### The Robot Calibration Folder
@@ -169,7 +169,7 @@ TODO - CLI flags
 
 ### APT Package Manager
 
-APT is a system package manager used to install applications. It can install packages that have no GUI. For example, all ROS2 software is installed through APT. The APT CLI enables you to introspect and install new software onto Stretch. Since APT makes changes at the system level, it requires "super user access", which means each of the commands below is preceded by `sudo` and will ask for your password.
+APT is a system package manager used to install applications. It can install packages that have no GUI. For example, all ROS 2 software is installed through APT. The APT CLI enables you to introspect and install new software onto Stretch. Since APT makes changes at the system level, it requires "super user access", which means each of the commands below is preceded by `sudo` and will ask for your password.
 
 | Command         | Arguments                   | Description                                                   | Examples              |
 |-----------------|-----------------------------|---------------------------------------------------------------|-----------------------|

--- a/developing/cli.md
+++ b/developing/cli.md
@@ -96,11 +96,11 @@ For<span class="w"> </span>use<span class="w"> </span>with<span class="w"> </spa
 <span class="k">         hello-robot-stretch-factory = </span><span class="m">0.4.13</span>
 <span class="k">         hello-robot-stretch-diagnostics = </span><span class="m">0.0.14</span>
 <span class="k">         hello-robot-stretch-urdf = </span><span class="m">0.0.18</span>
-<span class="s">[Pass] ROS2 Humble is ready</span>
+<span class="s">[Pass] ROS 2 Humble is ready</span>
 <span class="k">         Workspace at ~/ament_ws/src/stretch_ros2</span>
 </code></pre></div>
 
-In addition to checking the robot's hardware, this tool also prints out a software report. This includes which version of Stretch's Python, ROS2, etc. software your system has installed. Check out the [Keeping your Software Up-to-date](../../../software/updating_software/#identifying-your-current-software) guide for a how-to on using this report to keep your robot's software up-to-date.
+In addition to checking the robot's hardware, this tool also prints out a software report. This includes which version of Stretch's Python, ROS 2, etc. software your system has installed. Check out the [Keeping your Software Up-to-date](../../../software/updating_software/#identifying-your-current-software) guide for a how-to on using this report to keep your robot's software up-to-date.
 
 ### `stretch_robot_home.py`
 [Link to source code](https://github.com/hello-robot/stretch_body/blob/master/tools/bin/stretch_robot_home.py)

--- a/developing/onboot.md
+++ b/developing/onboot.md
@@ -28,7 +28,7 @@ Notice the 3 sections: Unit, Service, and Install.
 
 "Unit" describes the service and declares what the service needs. For web teleop, we need the robot to be connected to the network before launching our application, so we say `Wants=network-online.target` and `After=network-online.target`. There are many targets available. For example, you could target `graphical-session.target` if your application needs a screen to render to. Also notice `ExecStartPre=/bin/sh -c 'until ping -c1 web.hello-robot.com; do sleep 1; done;'` in the next section, which is a reliable way of ensuring the robot is connected to the network **and** able to connect to web.hello-robot.com before launching the service.
 
-"Service" describes what the service should run. `ExecStart=/home/hello-robot/ament_ws/src/stretch_web_teleop/launch_interface.sh -f` is telling systemd that I want it to run the `launch_interface.sh` bash script in my ROS2 workspace. I use the absolute path including `/home/hello-robot` because there is only one user on my robot called "hello-robot" and my unit file is specific to the "hello-robot" user. Here's what launch_interface.sh looks like:
+"Service" describes what the service should run. `ExecStart=/home/hello-robot/ament_ws/src/stretch_web_teleop/launch_interface.sh -f` is telling systemd that I want it to run the `launch_interface.sh` bash script in my ROS 2 workspace. I use the absolute path including `/home/hello-robot` because there is only one user on my robot called "hello-robot" and my unit file is specific to the "hello-robot" user. Here's what launch_interface.sh looks like:
 
 ```bash
 #!/bin/bash
@@ -55,7 +55,7 @@ echo "Stopping previous instances..."
 echo "Reload USB bus..."
 sudo udevadm control --reload-rules && sudo udevadm trigger &>> $REDIRECT_LOGFILE
 
-echo "Start ROS2..."
+echo "Start ROS 2..."
 sleep 2;
 screen -dm -S "web_teleop_ros" ros2 launch stretch_web_teleop web_interface.launch.py $MAP_ARG $TTS_ARG &>> $REDIRECT_LOGFILE
 sleep 3;
@@ -65,12 +65,12 @@ Notice that almost every command has `&>> $REDIRECT_LOGFILE` after it. The reaso
 
 This bash script performs four steps before starting the application:
 
- - Setting up the environment. It's important that env vars like HELLO_FLEET_ID are set and that ROS2 is enabled if your application is based on ROS2
+ - Setting up the environment. It's important that env vars like HELLO_FLEET_ID are set and that ROS 2 is enabled if your application is based on ROS 2
  - Freeing the robot process. Systemd can automatically restart services if they experience an error, so it's nice for this script to ensure the robot is freed up before continuing.
  - Stopping previous instances of web teleop.
  - Reloading the USB bus. `network-online.target` comes after the USB bus is configured in the boot sequence, but it doesn't hurt to ensure USB is ready.
 
-Lastly, the script launches our Web Teleop ROS2 application inside of GNU `screen`. We use `screen` because it collects ROS2 logs in a nicer way than other tools. However, because `screen` launches another process to run the app, we need to inform systemd that the application is still running in the background. Hence, we include `RemainAfterExit=yes` in the unit file
+Lastly, the script launches our Web Teleop ROS 2 application inside of GNU `screen`. We use `screen` because it collects ROS 2 logs in a nicer way than other tools. However, because `screen` launches another process to run the app, we need to inform systemd that the application is still running in the background. Hence, we include `RemainAfterExit=yes` in the unit file
 
 In the last section, "Install", we set `WantedBy=graphical-session.target`. It's important that our service is wanted by some other service, otherwise our service would never be executed by systemd. By telling systemd that our service is wanted by `graphical-session.target`, which is part of the boot sequence, our service also becomes part of the boot sequence.
 
@@ -93,7 +93,7 @@ This allows ALL users to run `shutdown`, `udevadm`, `pkill`, and `wifi-connect` 
 
 ### Where to put unit files
 
-The unit file described above is a "user unit file", as opposed to a "system unit file". User unit files run when the user logins. By default, the "hello-robot" user is configured to login automatically on boot. Furthermore, since the Web Teleop unit file needs a ROS2 workspace in the "hello-robot" user, it makes sense to use a user unit file.
+The unit file described above is a "user unit file", as opposed to a "system unit file". User unit files run when the user logins. By default, the "hello-robot" user is configured to login automatically on boot. Furthermore, since the Web Teleop unit file needs a ROS 2 workspace in the "hello-robot" user, it makes sense to use a user unit file.
 
 User unit files live in the `~/.config/systemd/user` directory. So when installing the Web Teleop application to launch on boot, we run:
 

--- a/mkdocs_rt.yml
+++ b/mkdocs_rt.yml
@@ -83,9 +83,9 @@ extra:
 
 nav:
   - Getting Started: ./getting_started.md
-  - ROS2 Basics:
+  - ROS 2 Basics:
     - Creating Packages & Nodes: ./writing_nodes.md
-    - Introduction to ROS2 Client (rclpy): ./intro_to_ros2.md
+    - Introduction to ROS 2 Client (rclpy): ./intro_to_ros2.md
     - Introduction to HelloNode: ./intro_to_hellonode.md
   - Simulation Tutorial: ./stretch_simulation.md
   - Teleoperation: ./teleoperating_stretch.md

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -14,12 +14,9 @@ Ensure that:
 
 ## Robot Operating System 2 (ROS 2)
 
-ROS 2 is the successor to ROS,  The ROS in ROS 2 stands for "robot operating system", but despite the name, ROS is not an operating system. It's a middleware framework that is a collection of transport protocols, development and debugging tools, and open-source packages.
+ROS 2 is the successor to ROS. The ROS in ROS 2 stands for "robot operating system", but despite the name, ROS is not an operating system. It's a middleware framework that is a collection of transport protocols, development and debugging tools, and open-source packages.
 
 As a transport protocol, ROS enables distributed communication via messages between nodes. As a development and debugging toolkit, ROS provides build systems that allow for writing applications in a wide variety of languages (Python and C++ are used in this tutorial track), a launch system to manage the execution of multiple nodes simultaneously, and command line tools to interact with the running system. Finally, as a popular ecosystem, there are many open-source ROS packages that allow users to quickly prototype with new sensors, actuators, planners, perception stacks, and more.
-
-
-Despite the name, ROS is not an operating system. ROS is a middleware framework that is a collection of transport protocols, development and debugging tools, and open-source packages. As a transport protocol, ROS enables distributed communication via messages between nodes. As a development and debugging toolkit, ROS provides build systems that allow for writing applications in a wide variety of languages (Python and C++ are used in this tutorial track), a launch system to manage the execution of multiple nodes simultaneously, and command line tools to interact with the running system. Finally, as a popular ecosystem, there are many open-source ROS packages that allow users to quickly prototype with new sensors, actuators, planners, perception stacks, and more.
 
 This tutorial track is for users looking to get familiar with programming Stretch robots via ROS 2. We recommend going through the tutorials in the following order:
 
@@ -27,21 +24,21 @@ This tutorial track is for users looking to get familiar with programming Stretc
 
 |  | Tutorial                                                                        | Description                                        |
 |--|---------------------------------------------------------------------------------|----------------------------------------------------|
-| 1 | [Creating your own package, launch files, nodes](writing_nodes.md)                                              | Setup instructions for ROS 2 on Stretch|
-| 2 | [Simulation Tutorial](stretch_simulation.md)                                       | Explore the client library used in ROS2 |
+| 1 | [Creating your own package, launch files, nodes](writing_nodes.md)                                              | Setup instructions for ROS 2 on Stretch.|
+| 2 | [Simulation Tutorial](stretch_simulation.md)                                       | Explore the client library used in ROS 2. |
 | 3 | [Teleoperating Stretch](teleoperating_stretch.md)                                  | Control Stretch with a Keyboard or a Gamepad controller. |
 | 4 | [RViz Basics](rviz_basics.md)                                                      | Visualize topics in Stretch. |
 | 5 | [Follow Joint Trajectory Commands](follow_joint_trajectory.md)                     | Control joints using joint trajectory server. |
-| 6 | [Introduction to HelloNode](intro_to_hellonode.md)                                 | Explore the Hello Node class to create a ROS2 node for Stretch |
-| 7 | [Robot Driver](robot_drivers.md)                                               | ROS2 Wrapper for the python API. |
+| 6 | [Introduction to HelloNode](intro_to_hellonode.md)                                 | Explore the HelloNode class to create a ROS 2 node for Stretch. |
+| 7 | [Robot Driver](robot_drivers.md)                                               | ROS 2 Wrapper for the python API. |
 | 8 | [Twist Control](twist_control.md)                                               | Using Twist messages to control the mobile base. |
 | 9 | [Sensors](sensors_tutorial.md)                                               | Stretch sensors including the ReSpeaker microphone array, IMU, bump sensors, and cliff sensors. |
 | 10 | [Nav2 Stack](navigation_overview.md)                                               | Motion planning and control for mobile base. |
-| 11 | [Perception](perception.md)                                                        | Use the Realsense D435i camera to visualize the environment. |
+| 11 | [Perception](perception.md)                                                        | Use the RealSense D435i camera to visualize the environment. |
 | 12 | [Deep Perception](deep_perception.md)                                                        | Perception using Deep Learning. |
 | 13 | [ArUco Marker Detection](aruco_marker_detection.md)                               | Localize objects using ArUco markers. |
 | 14 | [Offloading Computation Tutorial](remote_compute.md)                               | Offloading computationally intensive processes. |
-| 15 | [Avoiding Race Conditions and Deadlocks](avoiding_deadlocks_race_conditions.md)          | Learn how to avoid Race Conditions and Deadlocks |
+| 15 | [Avoiding Race Conditions and Deadlocks](avoiding_deadlocks_race_conditions.md)          | Learn how to avoid Race Conditions and Deadlocks. |
 | 16 | [Autonomy Demos](demo_hello_world.md)                               | A few demos showcasing Stretch's autonomous capabilities. |
 | 17 | [FUNMAP](https://github.com/hello-robot/stretch_ros2/tree/humble/stretch_funmap)  | Fast Unified Navigation, Manipulation and Planning. |
 
@@ -56,13 +53,13 @@ To help get you started on your software development, here are examples of nodes
 | 1 | [Voice to Text](speech_to_text.md)                                                             |  Interpret speech and save transcript to a text file.| 
 | 2 | [Voice Teleoperation of Base](voice_teleop.md)                                               |  Use speech to teleoperate the mobile base.|
 | 3 | [Filter Laser Scans](lidar_filtering.md)                                                |  Publish new scan ranges that are directly in front of Stretch.| 
-| 4 | [Give Stretch a Balloon](rviz_markers.md)                                            |  Create a "balloon" marker that goes where ever Stretch goes.|
+| 4 | [Give Stretch a Balloon](rviz_markers.md)                                            |  Create a "balloon" marker that goes wherever Stretch goes.|
 | 5 | [Align to ArUco](align_to_aruco.md)                                                      |  Detect ArUco fiducials using OpenCV and align to them.|
 | 6 | [ArUco Tag Locator](aruco_locator.md)                               |  Actuate the head to locate a requested ArUco marker tag and return a transform.|
 | 7 | [Print Joint States](joint_states.md)                                                |  Print the joint states of Stretch.| 
 | 8 | [Store Effort Values](joint_effort_plotting.md)                                               |  Print, store, and plot the effort values of the Stretch robot.| 
 | 9 | [Tf2 Broadcaster and Listener](tf2_transforms.md)                                            |  Create a tf2 broadcaster and listener.|
-| 10 | [Capture Image](realsense_camera.md)                                                             |  Capture images from the RealSense camera data.| 
+| 10 | [Capture Image](realsense_camera.md)                                                             |  Capture images from RealSense camera data.| 
 | 11 | [Mobile Base Collision Avoidance](collision_avoidance.md)                                   |  Stop Stretch from running into a wall.| 
 | 12 | [Obstacle Avoider](obstacle_avoider.md)                                                  |  Avoid obstacles using the planar lidar. |
 <!--| 11 | [PointCloud Transformation](example_11.md)      |  Convert PointCloud2 data to a PointCloud and transform to a different frame.| -->

--- a/ros2/align_to_aruco.md
+++ b/ros2/align_to_aruco.md
@@ -4,7 +4,7 @@ ArUco markers are a type of fiducials that are used extensively in robotics for 
 
 There are three main parameters to creating an ArUco tag:
 
-- Dictionary Size (Use 6x6_250 when using Stretch tutorials or ROS2 nodes, this is explained more [below](#aruco-detection))
+- Dictionary Size (Use 6x6_250 when using Stretch tutorials or ROS 2 nodes, this is explained more [below](#aruco-detection))
 - ID (A unique identifier for the tag, see [Create a New ArUco Marker](#create-a-new-aruco-marker) for reserved IDs)
 - Marker Size (The physical dimensions of the tag in mm, this can be customized freely.)
 

--- a/ros2/intro_to_ros2.md
+++ b/ros2/intro_to_ros2.md
@@ -170,12 +170,12 @@ Notice that the spin method manifests itself as the spin_until_future_complete()
 
 ### What is ROS_DOMAIN_ID?
 
-ROS_DOMAIN_ID is an environment variable that determines which DDS (Data Distribution Service) domain your ROS2 nodes will communicate on. Think of it as a "channel" or "network ID" - only nodes with the same ROS_DOMAIN_ID can discover and communicate with each other.
+ROS_DOMAIN_ID is an environment variable that determines which DDS (Data Distribution Service) domain your ROS 2 nodes will communicate on. Think of it as a "channel" or "network ID" - only nodes with the same ROS_DOMAIN_ID can discover and communicate with each other.
 
 This is particularly useful in environments where:
-- Multiple robots or ROS2 systems are running on the same network
-- Multiple users are developing ROS2 applications simultaneously
-- You want to isolate your ROS2 communication from other systems
+- Multiple robots or ROS 2 systems are running on the same network
+- Multiple users are developing ROS 2 applications simultaneously
+- You want to isolate your ROS 2 communication from other systems
 
 The ROS_DOMAIN_ID can be any integer from 0 to 101 (some values may be reserved depending on your DDS implementation). The default value is 0.
 
@@ -184,7 +184,7 @@ The ROS_DOMAIN_ID can be any integer from 0 to 101 (some values may be reserved 
 When working with Stretch robots, setting the correct ROS_DOMAIN_ID is crucial because:
 
 1. **Multi-robot environments**: If you have multiple Stretch robots on the same network, each should use a different ROS_DOMAIN_ID to prevent cross-talk
-2. **Shared networks**: In lab or classroom settings, different users' ROS2 nodes won't interfere with each other if they use different domain IDs
+2. **Shared networks**: In lab or classroom settings, different users' ROS 2 nodes won't interfere with each other if they use different domain IDs
 3. **Debugging**: You can isolate your development environment from production systems
 
 ### Setting ROS_DOMAIN_ID in the Terminal
@@ -204,7 +204,7 @@ echo $ROS_DOMAIN_ID
 This setting will only persist for the current terminal session. Once you close the terminal, the setting is lost.
 
 !!! warning
-    All terminals where you run ROS2 nodes that need to communicate with each other must have the same ROS_DOMAIN_ID set. If you launch the Stretch driver in one terminal with `ROS_DOMAIN_ID=42` and try to run your node in another terminal with `ROS_DOMAIN_ID=0`, they won't be able to see each other!
+    All terminals where you run ROS 2 nodes that need to communicate with each other must have the same ROS_DOMAIN_ID set. If you launch the Stretch driver in one terminal with `ROS_DOMAIN_ID=42` and try to run your node in another terminal with `ROS_DOMAIN_ID=0`, they won't be able to see each other!
 
 ### Setting ROS_DOMAIN_ID Permanently in ~/.bashrc
 
@@ -247,7 +247,7 @@ You can always check what ROS_DOMAIN_ID is currently set:
 echo $ROS_DOMAIN_ID
 ```
 
-If this returns an empty line, it means ROS_DOMAIN_ID is not set, and ROS2 will use the default value of 0.
+If this returns an empty line, it means ROS_DOMAIN_ID is not set, and ROS 2 will use the default value of 0.
 
 ### Example: Using ROS_DOMAIN_ID with Multiple Robots
 

--- a/ros2/jogging.md
+++ b/ros2/jogging.md
@@ -1,10 +1,10 @@
-# Motion Commands in ROS2
+# Motion Commands in ROS 2
 
 ## Quickstart
 
 Sending motion commands is as easy as:
 
- 1. Launch the ROS2 driver in a terminal:
+ 1. Launch the ROS 2 driver in a terminal:
     ```{.bash .shell-prompt .copy}
     ros2 launch stretch_core stretch_driver.launch.py
     ```
@@ -18,7 +18,7 @@ Sending motion commands is as easy as:
 
 ## Writing a node
 
-You can also write a ROS2 node to send motion commands:
+You can also write a ROS 2 node to send motion commands:
 
 ```python
 import hello_helpers.hello_misc as hm
@@ -108,7 +108,7 @@ The revolute joints will have their limits published in radians, and the prismat
 
 ## Translating and rotating the base 
 
-You can also write a ROS2 node to send motion commands to the base:
+You can also write a ROS 2 node to send motion commands to the base:
 
 ```python
 import hello_helpers.hello_misc as hm

--- a/ros2/realsense_camera.md
+++ b/ros2/realsense_camera.md
@@ -116,7 +116,7 @@ from sensor_msgs.msg import Image
 from cv_bridge import CvBridge, CvBridgeError
 ```
 
-The `sensor_msgs.msg` is imported so that we can subscribe to ROS `Image` messages. Import [CvBridge](http://wiki.ros.org/cv_bridge) to convert between ROS `Image` messages and OpenCV images and the `Node` is necessary to create a node in ROS2.
+The `sensor_msgs.msg` is imported so that we can subscribe to ROS `Image` messages. Import [CvBridge](http://wiki.ros.org/cv_bridge) to convert between ROS `Image` messages and OpenCV images and the `Node` is necessary to create a node in ROS 2.
 
 ```python
 def __init__(self):

--- a/ros2/remote_compute.md
+++ b/ros2/remote_compute.md
@@ -4,13 +4,13 @@ In this tutorial, we will explore the method for offloading computationally inte
 - Increasing robot's efficiency by offloading high-power consuming processes. 
 - Utilizing available GPU hardware on powerful workstations to run large deep learning models.
 
-We will delve into the process of **offloading [Stretch Deep Perception](https://github.com/hello-robot/stretch_ros2/tree/humble/stretch_deep_perception) ROS2 nodes**. These nodes are known for their demanding computational requirements and are frequently used in [Stretch Demos](https://github.com/hello-robot/stretch_ros2/tree/humble/stretch_demos). 
+We will delve into the process of **offloading [Stretch Deep Perception](https://github.com/hello-robot/stretch_ros2/tree/humble/stretch_deep_perception) ROS 2 nodes**. These nodes are known for their demanding computational requirements and are frequently used in [Stretch Demos](https://github.com/hello-robot/stretch_ros2/tree/humble/stretch_demos). 
 
-*NOTE: All Stretch ROS2 packages are developed with Humble distro.*
+*NOTE: All Stretch ROS 2 packages are developed with Humble distro.*
 
 ## 1. Setting a ROS_DOMAIN_ID
 
-ROS2 utilizes [DDS](https://design.ros2.org/articles/ros_on_dds.html) as the default middleware for communication. **DDS enables nodes within the same physical network to seamlessly discover one another and establish communication, provided they share the same [ROS_DOMAIN_ID](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Domain-ID.html)**. This powerful mechanism ensures secure message passing between remote nodes as intended.
+ROS 2 utilizes [DDS](https://design.ros2.org/articles/ros_on_dds.html) as the default middleware for communication. **DDS enables nodes within the same physical network to seamlessly discover one another and establish communication, provided they share the same [ROS_DOMAIN_ID](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Domain-ID.html)**. This powerful mechanism ensures secure message passing between remote nodes as intended.
 
 By default, all ROS 2 nodes are configured with domain ID 0. To avoid conflicts, select a domain ID from the range of 0 to 101, and then set this chosen domain ID as the value for the `ROS_DOMAIN_ID` environment variable in both the Workstation and the Robot.
 ```{.bash .shell-prompt}
@@ -18,15 +18,15 @@ export ROS_DOMAIN_ID=<ID>
 ```
 
 ## 2. Setup the Workstation to work with Stretch
-The workstation needs to be installed with the stretch related ros2 packages to have access to robot meshes for Visualization in Rviz, custom interfaces dependencies and essential perception packages.
+The workstation needs to be installed with the stretch related ROS 2 packages to have access to robot meshes for Visualization in Rviz, custom interfaces dependencies and essential perception packages.
 
-This section assumes the workstation already has an active ROS2 distro and colcon dependencies pre-installed.
-You can find [ROS2 Installation step for Ubuntu here](https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Install-Binary.html#).
+This section assumes the workstation already has an active ROS 2 distro and colcon dependencies pre-installed.
+You can find [ROS 2 Installation step for Ubuntu here](https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Install-Binary.html#).
 
 
 #### Setup Essential stretch_ros2 Packages 
 
-Make sure the ROS2 distro is sourced.
+Make sure the ROS 2 distro is sourced.
 ```{.bash .shell-prompt}
 source /opt/ros/humble/setup.bash
 ```

--- a/ros2/robot_drivers.md
+++ b/ros2/robot_drivers.md
@@ -1,6 +1,6 @@
 # Robot Drivers
 
-This tutorial introduces the ROS2 drivers for Stretch and its sensors. These drivers reside in the `stretch_core` package, which is part of a suite of ROS2 packages available open-source [on Github](https://github.com/hello-robot/stretch_ros2/tree/humble/stretch_core#overview).
+This tutorial introduces the ROS 2 drivers for Stretch and its sensors. These drivers reside in the `stretch_core` package, which is part of a suite of ROS 2 packages available open-source [on Github](https://github.com/hello-robot/stretch_ros2/tree/humble/stretch_core#overview).
 
 ## Stretch Driver
 

--- a/ros2/stretch_simulation.md
+++ b/ros2/stretch_simulation.md
@@ -1,6 +1,6 @@
 # Stretch Simulation Tutorial
 
-This tutorial will guide you through setting up and using the Stretch robot simulation in ROS2.
+This tutorial will guide you through setting up and using the Stretch robot simulation in ROS 2.
 
 Note: You do not need to follow this tutorial if you are running on a Stretch robot.
 
@@ -16,7 +16,7 @@ By the end of this tutorial, you'll be able to:
 
 - Use the simulation for navigation and mapping
 
-- Integrate the simulation with your own ROS2 applications
+- Integrate the simulation with your own ROS 2 applications
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ Before starting this tutorial, you should have:
 
 - Basic familiarity with Linux command line
 
-- Understanding of ROS2 concepts (nodes, topics, services). If you're new to ROS2 concepts, we recommend first reading through the [Introduction to ROS2](intro_to_ros2.md) tutorial.
+- Understanding of ROS 2 concepts (nodes, topics, services). If you're new to ROS 2 concepts, we recommend first reading through the [Introduction to ROS 2](intro_to_ros2.md) tutorial.
 
 - A computer meeting the system requirements below
 
@@ -41,32 +41,32 @@ Before starting this tutorial, you should have:
 
 ## Installation Guide
 
-### Step 1: Install ROS2 Humble (10 minutes)
+### Step 1: Install ROS 2 Humble (10 minutes)
 
-> **Note**: Skip this step if you're running on a Stretch robot, as ROS2 is already installed.
+> **Note**: Skip this step if you're running on a Stretch robot, as ROS 2 is already installed.
 
 ```bash
 # Add universe repository for additional packages
 sudo apt install software-properties-common
 sudo add-apt-repository universe
 
-# Install curl for downloading ROS2 keys
+# Install curl for downloading ROS 2 keys
 sudo apt update && sudo apt install curl -y
 
-# Add ROS2 official repository
+# Add ROS 2 official repository
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
-# Update package list and install ROS2
+# Update package list and install ROS 2
 sudo apt update
 sudo apt install ros-humble-desktop ros-dev-tools rviz python3-pip
 
-# Source ROS2 environment (you'll need to do this in every new terminal)
+# Source ROS 2 environment (you'll need to do this in every new terminal)
 source /opt/ros/humble/setup.bash
 ```
 
-**Expected output**: After installation, you should be able to run `ros2 --help` and see the ROS2 command options.
+**Expected output**: After installation, you should be able to run `ros2 --help` and see the ROS 2 command options.
 
 ### Step 2: Install Node.js and npm (5 minutes)
 
@@ -82,11 +82,11 @@ node --version  # Should show v22.x.x
 npm --version   # Should show npm version
 ```
 
-### Step 3: Set up the ROS2 Workspace (1 hour)
+### Step 3: Set up the ROS 2 Workspace (1 hour)
 
 > **Note**: Skip this step if you're running on a Stretch robot.
 
-A ROS2 workspace is a directory containing ROS2 packages. We'll create an `ament_ws` workspace with all the necessary Stretch packages.
+A ROS 2 workspace is a directory containing ROS 2 packages. We'll create an `ament_ws` workspace with all the necessary Stretch packages.
 
 **⚠️ Warning**: This will delete any existing `~/ament_ws` directory. Back up important files first.
 
@@ -94,7 +94,7 @@ A ROS2 workspace is a directory containing ROS2 packages. We'll create an `ament
 # Download and run the workspace setup script
 curl -sL https://raw.githubusercontent.com/hello-robot/stretch_ros2/refs/heads/humble/stretch_simulation/stretch_create_ament_workspace.sh > /tmp/stretch_create_ament_workspace.sh && sudo bash /tmp/stretch_create_ament_workspace.sh
 
-# Add ROS2 environment to your shell profile (optional but recommended)
+# Add ROS 2 environment to your shell profile (optional but recommended)
 echo 'source ~/ament_ws/install/setup.bash' >> ~/.bashrc
 ```
 
@@ -114,7 +114,7 @@ audio_common  realsense-ros  respeaker_ros2  ros2_numpy  rosbridge_suite  sllida
 URDF (Unified Robot Description Format) files describe the robot's physical structure, joints, and sensors. This step downloads the 3D models and configurations for the Stretch robot.
 
 ```bash
-# Source the ROS2 environment
+# Source the ROS 2 environment
 source ~/ament_ws/install/setup.bash
 
 # Install Stretch URDF tools
@@ -126,7 +126,7 @@ git clone https://github.com/hello-robot/stretch_urdf.git --depth 1 /tmp/stretch
 # Install Stretch body
 python3 -m pip install hello-robot-stretch-body
 
-# Update URDF files for ROS2
+# Update URDF files for ROS 2
 python3 /tmp/stretch_urdf/tools/stretch_urdf_ros_update.py
 python3 /tmp/stretch_urdf/tools/stretch_urdf_ros_update.py --ros2_rebuild
 ```
@@ -144,7 +144,7 @@ d405  d435i  stretch_description.xacro  stretch_main.xacro  # ... and many more 
 # Upgrade pip (important for dependency installation)
 pip3 install --upgrade pip
 
-# Source ROS2 environment
+# Source ROS 2 environment
 source ~/ament_ws/install/setup.bash
 
 # Run interactive setup script (will ask about robocasa environments)
@@ -175,7 +175,7 @@ ros2 launch stretch_simulation stretch_mujoco_driver.launch.py mode:=navigation
 
 **Expected output**:
 - A Mujoco viewer window should open showing the Stretch robot in a kitchen environment
-- ROS2 nodes should start without errors
+- ROS 2 nodes should start without errors
 - You should see log messages indicating successful initialization
 
 **Troubleshooting**:
@@ -354,7 +354,7 @@ ros2 param set /global_costmap/global_costmap inflation_layer.inflation_radius 0
 ros2 param set /local_costmap/local_costmap inflation_layer.inflation_radius 0.20
 ```
 
-## ROS2 Integration
+## ROS 2 Integration
 
 ### Key Topics
 
@@ -535,7 +535,7 @@ export MUJOCO_GL=egl  # For hardware acceleration
 
 - Check GPU drivers are properly installed
 
-**3. ROS2 nodes not communicating**
+**3. ROS 2 nodes not communicating**
 ```bash
 # Check if nodes are running
 ros2 node list

--- a/ros2/writing_nodes.md
+++ b/ros2/writing_nodes.md
@@ -189,9 +189,11 @@ Let's break down what this code does:
 1. **Imports**: We import the necessary ROS 2 Python libraries and message types
 2. **Class Definition**: We create a class that inherits from `Node`, which is the base class for all ROS 2 nodes
 3. **Constructor (`__init__`)**:
+
    - Calls the parent constructor with our node name
    - Creates a subscription to the `/joint_states` topic
    - Sets up logging messages
+
 4. **Callback Function**: This function gets called every time a new message arrives on the subscribed topic
 5. **Main Function**: Initializes ROS 2, creates our node, and keeps it running
 
@@ -248,6 +250,7 @@ Summary: 1 package finished [2.56s]
 ```
 
 If you encounter any errors, double-check that:
+
 - Your Python code has correct indentation
 - The `package.xml` and `setup.py` files are properly formatted
 - All file names match exactly
@@ -314,6 +317,7 @@ The joint state messages contain information about all of Stretch's joints:
 - **Effort**: Current effort/torque being applied to the joint
 
 Key joints you'll see include:
+
 - `joint_lift`: The vertical lift mechanism
 - `wrist_extension`: The telescoping arm extension
 - `joint_wrist_yaw`: Wrist rotation
@@ -448,27 +452,34 @@ This enhanced version will print a summary every 5 seconds showing only the join
 ### Build Errors
 
 **Problem**: `colcon build` fails with Python syntax errors
+
 - **Solution**: Check your Python code for proper indentation and syntax. Python is sensitive to indentation - use consistent spaces (typically 4 spaces per level).
 
 **Problem**: Package not found during build
+
 - **Solution**: Make sure you're in the correct workspace directory (`~/ament_ws`) and that your package is in the `src` folder.
 
 **Problem**: Missing dependencies error
+
 - **Solution**: Ensure all required dependencies are listed in your `package.xml` file.
 
 ### Runtime Errors
 
 **Problem**: `ros2 run` command not found or package not found
-- **Solution**: Make sure you've sourced your workspace: `source ~/ament_ws/install/setup.bash`
+
+- **Solution**: Make sure you've sourced your workspace: `source ~/ament_ws/install/setup.bash`.
 
 **Problem**: Node starts but no messages are received
+
 - **Solution**:
-  1. Check that the Stretch driver is running: `ros2 launch stretch_core stretch_driver.launch.py`
-  2. Verify the topic exists: `ros2 topic list | grep joint_states`
-  3. Check if messages are being published: `ros2 topic echo /joint_states`
+
+  1. Check that the Stretch driver is running: `ros2 launch stretch_core stretch_driver.launch.py`.
+  2. Verify the topic exists: `ros2 topic list | grep joint_states`.
+  3. Check if messages are being published: `ros2 topic echo /joint_states`.
 
 **Problem**: Permission denied when running the node
-- **Solution**: Make sure your Python file has execute permissions: `chmod +x joint_state_subscriber.py`
+
+- **Solution**: Make sure your Python file has execute permissions: `chmod +x joint_state_subscriber.py`.
 
 ### Debugging Tips
 

--- a/ros2/writing_nodes.md
+++ b/ros2/writing_nodes.md
@@ -1,25 +1,25 @@
-# Writing ROS2 Nodes
+# Writing ROS 2 Nodes
 
 ## Introduction
 
-ROS2 nodes are the fundamental building blocks of any ROS2 application. A node is an executable that uses ROS2 to communicate with other nodes. Nodes can publish messages to topics, subscribe to topics to receive messages, provide services, or call services provided by other nodes. In this tutorial, you'll learn how to create your own ROS2 Python package and write a simple node that subscribes to Stretch's joint states.
+ROS 2 nodes are the fundamental building blocks of any ROS 2 application. A node is an executable that uses ROS 2 to communicate with other nodes. Nodes can publish messages to topics, subscribe to topics to receive messages, provide services, or call services provided by other nodes. In this tutorial, you'll learn how to create your own ROS 2 Python package and write a simple node that subscribes to Stretch's joint states.
 
-Think of nodes as individual programs that each have a specific responsibility - one node might handle camera data, another might control the robot's movement, and yet another might process sensor information. By breaking functionality into separate nodes, ROS2 applications become modular, easier to debug, and more maintainable.
+Think of nodes as individual programs that each have a specific responsibility - one node might handle camera data, another might control the robot's movement, and yet another might process sensor information. By breaking functionality into separate nodes, ROS 2 applications become modular, easier to debug, and more maintainable.
 
 ## Prerequisites
 
 Before starting this tutorial, you should have:
 
 1. **Basic Python knowledge**: Understanding of Python syntax, functions, and classes
-2. **ROS2 installation**: ROS2 Humble installed on your system (this comes pre-installed on Stretch robots)
+2. **ROS 2 installation**: ROS 2 Humble installed on your system (this comes pre-installed on Stretch robots)
 3. **Stretch robot setup**: Access to a Stretch robot or simulation environment
 4. **Basic terminal/command line familiarity**: Ability to navigate directories and run commands
 
-If you're new to ROS2 concepts, we recommend first reading through the [Introduction to ROS2](intro_to_ros2.md) tutorial.
+If you're new to ROS 2 concepts, we recommend first reading through the [Introduction to ROS 2](intro_to_ros2.md) tutorial.
 
-## Understanding the ROS2 Workspace Structure
+## Understanding the ROS 2 Workspace Structure
 
-Before we create our first node, let's understand how ROS2 organizes code. ROS2 uses a workspace structure where all your packages live in a `src` directory within your workspace. The standard workspace structure looks like this:
+Before we create our first node, let's understand how ROS 2 organizes code. ROS 2 uses a workspace structure where all your packages live in a `src` directory within your workspace. The standard workspace structure looks like this:
 
 ```
 ~/ament_ws/                    # Your workspace root
@@ -32,9 +32,9 @@ Before we create our first node, let's understand how ROS2 organizes code. ROS2 
     └── your_new_package/
 ```
 
-## Step 1: Creating a New ROS2 Python Package
+## Step 1: Creating a New ROS 2 Python Package
 
-Let's start by creating a new ROS2 package. A package is a collection of related nodes, launch files, configuration files, and other resources.
+Let's start by creating a new ROS 2 package. A package is a collection of related nodes, launch files, configuration files, and other resources.
 
 First, navigate to your workspace source directory:
 
@@ -88,11 +88,11 @@ This file tells Python how to install your package. Let's examine it:
 cat setup.py
 ```
 
-We'll need to modify this file to include our new node as an entry point so ROS2 can find and run it.
+We'll need to modify this file to include our new node as an entry point so ROS 2 can find and run it.
 
 ## Step 3: Writing Your First Node
 
-Now let's create our first ROS2 node that subscribes to the `/joint_states` topic and prints information about Stretch's joints.
+Now let's create our first ROS 2 node that subscribes to the `/joint_states` topic and prints information about Stretch's joints.
 
 Create a new Python file for our node:
 
@@ -112,7 +112,7 @@ from sensor_msgs.msg import JointState
 
 class JointStateSubscriber(Node):
     """
-    A ROS2 node that subscribes to joint states and prints joint information.
+    A ROS 2 node that subscribes to joint states and prints joint information.
     """
 
     def __init__(self):
@@ -159,9 +159,9 @@ class JointStateSubscriber(Node):
 
 def main(args=None):
     """
-    Main function to initialize ROS2, create the node, and spin.
+    Main function to initialize ROS 2, create the node, and spin.
     """
-    # Initialize ROS2 Python client library
+    # Initialize ROS 2 Python client library
     rclpy.init(args=args)
 
     # Create an instance of our node
@@ -186,14 +186,14 @@ if __name__ == '__main__':
 
 Let's break down what this code does:
 
-1. **Imports**: We import the necessary ROS2 Python libraries and message types
-2. **Class Definition**: We create a class that inherits from `Node`, which is the base class for all ROS2 nodes
+1. **Imports**: We import the necessary ROS 2 Python libraries and message types
+2. **Class Definition**: We create a class that inherits from `Node`, which is the base class for all ROS 2 nodes
 3. **Constructor (`__init__`)**:
    - Calls the parent constructor with our node name
    - Creates a subscription to the `/joint_states` topic
    - Sets up logging messages
 4. **Callback Function**: This function gets called every time a new message arrives on the subscribed topic
-5. **Main Function**: Initializes ROS2, creates our node, and keeps it running
+5. **Main Function**: Initializes ROS 2, creates our node, and keeps it running
 
 ## Step 4: Configuring Package Dependencies and Entry Points
 
@@ -220,11 +220,11 @@ entry_points={
 },
 ```
 
-This tells ROS2 that when someone runs `ros2 run stretch_joint_reader joint_state_subscriber`, it should execute the `main` function from our `joint_state_subscriber.py` file.
+This tells ROS 2 that when someone runs `ros2 run stretch_joint_reader joint_state_subscriber`, it should execute the `main` function from our `joint_state_subscriber.py` file.
 
 ## Step 5: Building Your Package
 
-Now that we've created our node and configured our package, we need to build it. ROS2 uses the `colcon` build system.
+Now that we've created our node and configured our package, we need to build it. ROS 2 uses the `colcon` build system.
 
 Navigate back to your workspace root:
 
@@ -342,7 +342,7 @@ from sensor_msgs.msg import JointState
 
 class FilteredJointStateSubscriber(Node):
     """
-    An enhanced ROS2 node that subscribes to joint states and filters for specific joints.
+    An enhanced ROS 2 node that subscribes to joint states and filters for specific joints.
     """
 
     def __init__(self):
@@ -438,7 +438,7 @@ source install/setup.bash
 Run the enhanced node:
 
 ```{.bash .shell-prompt}
-ros2 run stretch_joint_reader filtered_joint_subscriber
+ ros2 run stretch_joint_reader filtered_joint_subscriber
 ```
 
 This enhanced version will print a summary every 5 seconds showing only the joints you're interested in, making it easier to monitor specific parts of the robot.
@@ -472,7 +472,7 @@ This enhanced version will print a summary every 5 seconds showing only the join
 
 ### Debugging Tips
 
-1. **Use ROS2 command-line tools**:
+1. **Use ROS 2 command-line tools**:
    ```bash
    # List all available topics
    ros2 topic list
@@ -489,12 +489,12 @@ This enhanced version will print a summary every 5 seconds showing only the join
 
 2. **Add more logging**: Use `self.get_logger().info()`, `.warn()`, `.error()`, or `.debug()` to add debugging information to your code.
 
-3. **Check the ROS2 graph**: Use `rqt_graph` to visualize the connections between nodes:
+3. **Check the ROS 2 graph**: Use `rqt_graph` to visualize the connections between nodes:
    ```bash
    ros2 run rqt_graph rqt_graph
    ```
 
-## Understanding ROS2 Concepts
+## Understanding ROS 2 Concepts
 
 ### Topics and Messages
 
@@ -505,11 +505,11 @@ This enhanced version will print a summary every 5 seconds showing only the join
 
 ### Quality of Service (QoS)
 
-The queue size parameter (10 in our examples) is part of ROS2's Quality of Service system. It determines how many messages to buffer if your callback function can't process them fast enough.
+The queue size parameter (10 in our examples) is part of ROS 2's Quality of Service system. It determines how many messages to buffer if your callback function can't process them fast enough.
 
 ### Node Lifecycle
 
-1. **Initialization**: `rclpy.init()` sets up the ROS2 runtime
+1. **Initialization**: `rclpy.init()` sets up the ROS 2 runtime
 2. **Node Creation**: Creating your node instance
 3. **Spinning**: `rclpy.spin()` keeps the node alive and processes callbacks
 4. **Cleanup**: `destroy_node()` and `rclpy.shutdown()` clean up resources


### PR DESCRIPTION
This PR reviews the tutorial documentation and fixes several issues that affect clarity and website rendering.

Specifically, it addresses:

- Misspellings and minor wording errors

- Duplicate or malformed list items

- Indentation and Markdown formatting issues that caused improper rendering on the documentation site (still need to check the rendering on the website)