### PR TITLE
rm Perception Tutorial (replaced by RViz Tutorial)

### DIFF
--- a/mkdocs_rt.yml
+++ b/mkdocs_rt.yml
@@ -99,7 +99,6 @@ nav:
     - Overview: ./navigation_overview.md
     - Nav2 Basics: ./navigation_stack.md
     - Nav2 Simple Commander: ./navigation_simple_commander.md
-  - Perception Tutorial: ./perception.md
   - Deep Perception: ./deep_perception.md
   - ArUco Markers: ./aruco_marker_detection.md
   - Offloading Computation Tutorial: ./remote_compute.md


### PR DESCRIPTION
The `Perception Tutorial` was removed from `ROS 2 Tutorials` drop down menu, since it is already handled by `Rviz Tutorial`: https://docs.hello-robot.com/0.3/ros2/rviz_basics/